### PR TITLE
避免.import文件行尾被引擎自动改为LF, 导致与其他文件的CRLF不一致. 把所有文件行尾都设置为LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Normalize EOL for all files that Git considers text files.
+* text=auto eol=lf
+
+*.hdr binary


### PR DESCRIPTION
参考[官方案例](https://github.com/godotengine/godot-demo-projects)的仓库. 增加 .gitattributes 文件